### PR TITLE
Enable using Unix socket interface to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ that spawns `socat` to bridge `AF_UNIX` to `AF_INET`.
     ]}
 ```
 
+If your docker is configured to use unix socket (in case of Docker for Mac OSX)
+
+```erlang
+    {erldocker, [
+            {docker_http, <<"http+unix://%2Fvar%2Frun%2Fdocker.sock">>}
+    ]}
+```
 If your docker is configured to listen on a TCP port, you may use the following configuration:
 
 ```erlang

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 {deps, [
-    hackney,
-    jsx,
-    erlsh,
+    {hackney, "1.16.0"},
+    {jsx, "2.9.0"},
+    {erlsh, "0.1.0"},
     {fn, "0.3.0", {git, "https://github.com/reiddraper/fn", {tag, "0.3.0"}}},
-    lager,
-    active
+    {lager, "3.8.0"},
+    {active, "6.1.1"}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 {deps, [
-    {hackney, ".*", {git, "https://github.com/benoitc/hackney", {tag, "0.4.4"}}}
-    , {jsx, "1.4.3", {git, "https://github.com/talentdeficit/jsx", {tag, "v1.4.3"}}}
-    , {erlsh, ".*", {git, "https://github.com/proger/erlsh", "HEAD"}}
-    , {fn, "0.3.0", {git, "https://github.com/reiddraper/fn", {tag, "0.3.0"}}}
-    , {lager, ".*", {git, "https://github.com/basho/lager", {tag, "2.0.0"}}}
-    , {active, ".*", {git, "https://github.com/proger/active", "HEAD"}}
+    hackney,
+    jsx,
+    erlsh,
+    {fn, "0.3.0", {git, "https://github.com/reiddraper/fn", {tag, "0.3.0"}}},
+    lager,
+    active
 ]}.

--- a/run/sys.config
+++ b/run/sys.config
@@ -3,6 +3,9 @@
             {unixbridge_port, 32133},
             {docker_http, <<"http://localhost:32133">>}
             %{docker_http, <<"http://localhost:4243">>}
+
+            %% For using unix socket interface to docker
+            %{docker_http, <<"http+unix://%2Fvar%2Frun%2Fdocker.sock">>}
     ]},
 
     {lager, [

--- a/src/docker_container.erl
+++ b/src/docker_container.erl
@@ -28,7 +28,7 @@
 % @doc Identical to the docker ps command.
 containers() -> containers(default_args(containers)).
 containers(Args) ->
-    ?PROPLISTS(erldocker_api:get([containers, ps], Args)).
+    ?PROPLISTS(erldocker_api:get([containers, json], Args)).
 
 % @doc Identical to the docker inspect command, but can only be used with a container ID.
 container(CID) ->

--- a/src/erldocker_api.erl
+++ b/src/erldocker_api.erl
@@ -39,7 +39,7 @@ call(Method, Body, URL) when is_binary(URL) andalso is_binary(Body) ->
     ReqHeaders = [{<<"Content-Type">>, <<"application/json">>}],
     case hackney:request(Method, URL, ReqHeaders, Body, ?OPTIONS) of
         {ok, StatusCode, RespHeaders, Client} ->
-            {ok, RespBody, _Client1} = hackney:body(Client),
+            {ok, RespBody} = hackney:body(Client),
             case StatusCode of
                 X when X == 200 orelse X == 201 orelse X == 204 ->
                     case lists:keyfind(<<"Content-Type">>, 1, RespHeaders) of
@@ -70,7 +70,7 @@ read_body(Receiver, Client) ->
     end.
 
 argsencode([], Acc) ->
-    hackney_util:join(lists:reverse(Acc), <<"&">>);
+    hackney_bstr:join(lists:reverse(Acc), <<"&">>);
 argsencode ([{_K,undefined}|R], Acc) ->
     argsencode(R, Acc);
 argsencode ([{K,V}|R], Acc) ->

--- a/src/erldocker_app.erl
+++ b/src/erldocker_app.erl
@@ -9,11 +9,11 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    {ok, _Pid} = hackney:start_pool(erldocker_pool, [{timeout, 150000}, {pool_size, 1}]),
+    ok = hackney_pool:start_pool(erldocker_pool, [{timeout, 150000}, {pool_size, 1}]),
 
     erldocker_sup:start_link().
 
 stop(_State) ->
-    hackney:stop_pool(erldocker_pool),
+    hackney_pool:stop_pool(erldocker_pool),
 
     ok.


### PR DESCRIPTION
Support for unix-sockets is introduced in hackney in later releases. So using the latest versions.

Following is the command to be used to get information from docker SDK in Docker for Mac. This commit helps support this interface to Docker.

`curl --unix-socket /var/run/docker.sock http://localhost/info`

Made changes to erldocker to reflect API changes in hackney.

Signed-off-by: Vasu Dasari <vdasari@gmail.com>